### PR TITLE
Fix shebang in run-conversion.py

### DIFF
--- a/run-conversion.py
+++ b/run-conversion.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 from PIL import Image, ImageEnhance
 from pathlib import Path


### PR DESCRIPTION
Don't hard code the path to python3
this is a better shebang and it will work on more systems.